### PR TITLE
fix(admin): escape admin users table fields to prevent stored XSS

### DIFF
--- a/src/scripts/admin-users-page-helpers.ts
+++ b/src/scripts/admin-users-page-helpers.ts
@@ -3,6 +3,14 @@ import { t } from "@/scripts/i18n-runtime";
 
 export type UnknownRecord = Record<string, unknown>;
 
+const escapeHtml = (raw: unknown): string =>
+    String(raw || "")
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#039;");
+
 const getStr = (value: unknown, fallback = ""): string =>
     String(value || fallback).trim();
 
@@ -68,14 +76,19 @@ export const renderUsersRows = (
                     "member",
             );
             const roleLabel = resolveRoleLabel(userRecord, appRole);
-            const roleCell = `<span class="inline-flex items-center rounded-full px-2 py-1 text-xs ${resolveRoleBadgeClass(roleLabel)}">${roleLabel}</span>`;
+            // 关键渲染字段统一进行 HTML 转义，避免拼接 innerHTML 时出现注入。
+            const safeUserId = escapeHtml(userId);
+            const safeUserEmail = escapeHtml(userEmail);
+            const safeUsername = escapeHtml(username);
+            const safeRoleLabel = escapeHtml(roleLabel);
+            const roleCell = `<span class="inline-flex items-center rounded-full px-2 py-1 text-xs ${resolveRoleBadgeClass(roleLabel)}">${safeRoleLabel}</span>`;
             return `
 					<tr class="border-b border-(--line-divider) text-75">
-						<td class="py-2 pr-2">${userEmail}</td>
-						<td class="py-2 pr-2">${username}</td>
+						<td class="py-2 pr-2">${safeUserEmail}</td>
+						<td class="py-2 pr-2">${safeUsername}</td>
 						<td class="py-2 pr-2">${roleCell}</td>
 						<td class="py-2 pr-2">
-							<button class="text-xs text-red-500 hover:underline" data-action="delete" data-user-id="${userId}" data-username="${username}" data-email="${userEmail}">${t(I18nKey.adminUsersDeleteAccount)}</button>
+							<button class="text-xs text-red-500 hover:underline" data-action="delete" data-user-id="${safeUserId}" data-username="${safeUsername}" data-email="${safeUserEmail}">${t(I18nKey.adminUsersDeleteAccount)}</button>
 						</td>
 					</tr>
 				`;


### PR DESCRIPTION
### Motivation
- Prevent a stored XSS in the admin users list where unescaped user-provided fields (email/username/id/role) were interpolated into `innerHTML` and `data-*` attributes, allowing crafted emails to break out of attributes and inject event handlers or HTML.

### Description
- Added an `escapeHtml` helper and applied it to `userId`, `userEmail`, `username`, and `roleLabel` before assembling the users table row HTML in `src/scripts/admin-users-page-helpers.ts` to ensure visible cells and `data-*` attributes are safe.
- Kept the visible role badge styling intact while rendering the escaped role label text to preserve UI behavior.

### Testing
- Ran `pnpm check` and the repository checks completed with no errors. (passed)
- Ran `pnpm lint` and automatic fixes; lint completed successfully. (passed)
- Ran unit tests via the project test suite (`pnpm test`) and all tests passed (435 tests). (passed)
- Attempted `pnpm build` but the build failed in this environment due to an external Directus fetch failing during prerendering (`getStaticPaths` for `src/pages/og/[...slug].png.ts`), which is an infrastructure/external-service issue and not a regression introduced by this change. (build environment failure)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab8549e56883218035972d8183887b)