### PR TITLE
fix(api): enforce diary privacy flag in public diary list

### DIFF
--- a/src/server/api/v1/public/diaries.ts
+++ b/src/server/api/v1/public/diaries.ts
@@ -26,7 +26,10 @@ async function handleDiaryList(context: APIContext): Promise<Response> {
     const cached = await cacheManager.get<unknown>("diary-list", cacheKey);
     if (cached) return ok(cached);
 
-    const filter = filterPublicStatus();
+    // 日记公开列表除通用发布状态外，还必须显式限制为公开日记，避免私密内容泄露。
+    const filter: JsonObject = {
+        _and: [filterPublicStatus(), { praviate: { _eq: true } }],
+    };
     const [rows, total] = await Promise.all([
         readMany("app_diaries", {
             filter,


### PR DESCRIPTION
### Motivation
- The public diary list previously reused `filterPublicStatus()` which checks `status`/`is_public` but diaries use the `praviate` boolean for visibility, so private published diaries could be exposed.

### Description
- Update `handleDiaryList` in `src/server/api/v1/public/diaries.ts` to combine `filterPublicStatus()` with `{ praviate: { _eq: true } }` (via an `_and`) and add a short Chinese comment explaining the security intent.

### Testing
- Ran `pnpm check`, `pnpm lint` and `pnpm test` locally which all succeeded; `pnpm build` failed in this environment during static prerender due to a Directus fetch error in `src/pages/og/[...slug].png.ts` (external dependency), and is unrelated to the patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab89e81bec832180e65947c1e40668)